### PR TITLE
add try except handle KeyError for DCOnly collection method

### DIFF
--- a/ad_miner/sources/modules/neo4j_class.py
+++ b/ad_miner/sources/modules/neo4j_class.py
@@ -1113,40 +1113,43 @@ class Neo4j:
 
         logger.print_debug("[Done]")
 
-        if not requests_results["users_admin_on_servers_1"]:
-            requests_results["users_admin_on_servers_1"] = []
-        if not requests_results["users_admin_on_servers_2"]:
-            requests_results["users_admin_on_servers_2"] = []
+        try:
+            if not requests_results["users_admin_on_servers_1"]:
+                requests_results["users_admin_on_servers_1"] = []
+            if not requests_results["users_admin_on_servers_2"]:
+                requests_results["users_admin_on_servers_2"] = []
 
-        users_admin_on_servers_all_data = (
-            requests_results["users_admin_on_servers_1"]
-            + requests_results["users_admin_on_servers_2"]
-        )
-        users_admin_on_servers_all_data = [
-            dict(t) for t in {tuple(d.items()) for d in users_admin_on_servers_all_data}
-        ]
-        users_admin_on_servers = generic_computing.getCountValueFromKey(
-            users_admin_on_servers_all_data, "computer"
-        )
-        users_admin_on_servers_list = generic_computing.getListAdminTo(
-            users_admin_on_servers_all_data,
-            "computer",
-            "user",
-        )
-
-        if users_admin_on_servers is not None and users_admin_on_servers != {}:
-            servers_with_most_paths = users_admin_on_servers[
-                list(users_admin_on_servers.keys())[0]
+            users_admin_on_servers_all_data = (
+                requests_results["users_admin_on_servers_1"]
+                + requests_results["users_admin_on_servers_2"]
+            )
+            users_admin_on_servers_all_data = [
+                dict(t) for t in {tuple(d.items()) for d in users_admin_on_servers_all_data}
             ]
-        else:
-            servers_with_most_paths = []
+            users_admin_on_servers = generic_computing.getCountValueFromKey(
+                users_admin_on_servers_all_data, "computer"
+            )
+            users_admin_on_servers_list = generic_computing.getListAdminTo(
+                users_admin_on_servers_all_data,
+                "computer",
+                "user",
+            )
 
-        requests_results["users_admin_on_servers_list"] = users_admin_on_servers_list
-        requests_results["servers_with_most_paths"] = servers_with_most_paths
-        requests_results["users_admin_on_servers"] = users_admin_on_servers
-        requests_results["users_admin_on_servers_all_data"] = (
-            users_admin_on_servers_all_data
-        )
+            if users_admin_on_servers is not None and users_admin_on_servers != {}:
+                servers_with_most_paths = users_admin_on_servers[
+                    list(users_admin_on_servers.keys())[0]
+                ]
+            else:
+                servers_with_most_paths = []
+
+            requests_results["users_admin_on_servers_list"] = users_admin_on_servers_list
+            requests_results["servers_with_most_paths"] = servers_with_most_paths
+            requests_results["users_admin_on_servers"] = users_admin_on_servers
+            requests_results["users_admin_on_servers_all_data"] = (
+                users_admin_on_servers_all_data
+            )
+        except KeyError as ke:
+            print(f"KeyError: {ke}")
 
         # Dico for ACL anomaly and futur other controls to retrieve paths to DA on computer ID
         dico_paths_computers_to_DA = {}


### PR DESCRIPTION
Resolves error when you have "DCOnly" collection method.
Here's the stack trace:

```bash
[+] Split objects into types...
[+] [Done]
[+] Split paths to DA...
[+] [Done]
Traceback (most recent call last):
  File "/home/REDACTED/.local/bin/AD-miner", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/REDACTED/.local/share/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/__main__.py", line 212, in main
    requests_results = populate_data_and_cache(neo4j)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/REDACTED/.local/share/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/__main__.py", line 104, in populate_data_and_cache
    neo4j.compute_common_cache(requests_results)
  File "/home/REDACTED/.local/share/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/sources/modules/neo4j_class.py", line 1116, in compute_common_cache
    if not requests_results["users_admin_on_servers_1"]:
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Several other KeyError's that could use Try Except blocks throughout the codebase, but this PR fixes the breaking error for when you do CollectionMethod DCOnly.